### PR TITLE
Remove the CPEs that do not provide applicability information

### DIFF
--- a/nvd/cve.go
+++ b/nvd/cve.go
@@ -13,10 +13,10 @@ const (
 	cpeUpdateIndex  = 6
 	cpePartsLength  = 13
 
-	// ANY represent CPE ANY string punctuation
-	ANY = "*"
-	// NOT_APPLICABLE represents N/A CPE string punctuation
-	NOT_APPLICABLE = "-"
+	// Any represent CPE Any string punctuation
+	Any = "*"
+	// NotApplicable represents N/A CPE string punctuation
+	NotApplicable = "-"
 )
 
 var (
@@ -30,6 +30,7 @@ var (
 					{
 						Cpe23Uri:            "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
 						VersionEndExcluding: "1.2.0",
+						Vulnerable:          true,
 					},
 				},
 			},
@@ -41,10 +42,12 @@ var (
 				Operator: "OR",
 				CPEMatch: []*schema.NVDCVEFeedJSON10DefCPEMatch{
 					{
-						Cpe23Uri: "cpe:2.3:a:redhat:openshift_container_platform:3.0.0:*:*:*:*:*:*:*",
+						Cpe23Uri:   "cpe:2.3:a:redhat:openshift_container_platform:3.0.0:*:*:*:*:*:*:*",
+						Vulnerable: true,
 					},
 					{
-						Cpe23Uri: "cpe:2.3:a:redhat:openshift_container_platform:3.1.0:*:*:*:*:*:*:*",
+						Cpe23Uri:   "cpe:2.3:a:redhat:openshift_container_platform:3.1.0:*:*:*:*:*:*:*",
+						Vulnerable: true,
 					},
 				},
 			},
@@ -57,16 +60,19 @@ var (
 					{
 						Cpe23Uri:            "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
 						VersionEndExcluding: "1.2.7",
+						Vulnerable:          true,
 					},
 					{
 						Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
 						VersionStartIncluding: "1.3.0",
 						VersionEndExcluding:   "1.3.9",
+						Vulnerable:            true,
 					},
 					{
 						Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
 						VersionStartIncluding: "1.4.0",
 						VersionEndExcluding:   "1.4.3",
+						Vulnerable:            true,
 					},
 				},
 			},
@@ -74,6 +80,7 @@ var (
 	}
 )
 
+// FillMissingData fills NVD CVEs with missing data, e.g. affected product versions
 func FillMissingData(cves ...*schema.NVDCVEFeedJSON10DefCVEItem) {
 	tryUpdateCVEWithAffectedVersions(cves...)
 }
@@ -85,7 +92,9 @@ func tryUpdateCVEWithAffectedVersions(cves ...*schema.NVDCVEFeedJSON10DefCVEItem
 		}
 
 		updateRequired := true
+		filteredNodes := make([]*schema.NVDCVEFeedJSON10DefNode, 0, len(cve.Configurations.Nodes))
 		for _, node := range cve.Configurations.Nodes {
+			filteredCPE := make([]*schema.NVDCVEFeedJSON10DefCPEMatch, 0, len(node.CPEMatch))
 			for _, cpeMatch := range node.CPEMatch {
 				hasVersionInfo, err := cpeHasVersionInfo(cpeMatch)
 				if err != nil {
@@ -93,13 +102,27 @@ func tryUpdateCVEWithAffectedVersions(cves ...*schema.NVDCVEFeedJSON10DefCVEItem
 					continue
 				}
 
-				if hasVersionInfo {
-					updateRequired = false
+				if !hasVersionInfo {
+					continue
 				}
+
+				updateRequired = false
+				// We filter because we want to get rid of any CPE not providing applicability statement.
+				filteredCPE = append(filteredCPE, cpeMatch)
+			}
+
+			if len(filteredCPE) > 0 {
+				filteredNodes = append(filteredNodes, &schema.NVDCVEFeedJSON10DefNode{
+					CPEMatch: filteredCPE,
+					Operator: node.Operator,
+					Children: node.Children,
+					Negate:   node.Negate,
+				})
 			}
 		}
 
 		// For the concerned CVEs, if NVD is providing data, use it, else update CVE.
+		cve.Configurations.Nodes = filteredNodes
 		if updateRequired {
 			cve.Configurations.Nodes = append(cve.Configurations.Nodes, cvesWithoutFixedBy[cve.CVE.CVEDataMeta.ID]...)
 		}
@@ -130,12 +153,12 @@ func cpeHasVersionInfo(cpeMatch *schema.NVDCVEFeedJSON10DefCPEMatch) (bool, erro
 	}
 
 	// CPE string does not provide affected versions information
-	if version == NOT_APPLICABLE {
+	if version == NotApplicable {
 		return false, nil
 	}
 
 	// If CPE string matches any version check if ranges are provided. Note: CPE23URI provides affected versions and not ranges.
-	if version == ANY && update == ANY {
+	if version == Any && update == Any {
 		return cpeMatch.VersionStartIncluding != "" || cpeMatch.VersionEndIncluding != "" || cpeMatch.VersionEndExcluding != "", nil
 	}
 

--- a/nvd/cve_test.go
+++ b/nvd/cve_test.go
@@ -33,27 +33,21 @@ func TestUpdateFixedByWithNoDataFromNVD(t *testing.T) {
 			Operator: "OR",
 			CPEMatch: []*schema.NVDCVEFeedJSON10DefCPEMatch{
 				{
-					Vulnerable: true,
-					Cpe23Uri:   "cpe:2.3:a:kubernetes:kubernetes:-:*:*:*:*:*:*:*",
-				},
-			},
-		},
-		{
-			Operator: "OR",
-			CPEMatch: []*schema.NVDCVEFeedJSON10DefCPEMatch{
-				{
 					Cpe23Uri:            "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
 					VersionEndExcluding: "1.2.7",
+					Vulnerable:          true,
 				},
 				{
 					Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
 					VersionStartIncluding: "1.3.0",
 					VersionEndExcluding:   "1.3.9",
+					Vulnerable:            true,
 				},
 				{
 					Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
 					VersionStartIncluding: "1.4.0",
 					VersionEndExcluding:   "1.4.3",
+					Vulnerable:            true,
 				},
 			},
 		},
@@ -80,16 +74,19 @@ func TestUpdateFixedByWithDataFromNVD(t *testing.T) {
 						{
 							Cpe23Uri:            "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
 							VersionEndExcluding: "1.2.7",
+							Vulnerable:          true,
 						},
 						{
 							Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
 							VersionStartIncluding: "1.3.0",
 							VersionEndExcluding:   "1.3.9",
+							Vulnerable:            true,
 						},
 						{
 							Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
 							VersionStartIncluding: "1.4.0",
 							VersionEndExcluding:   "1.4.3",
+							Vulnerable:            true,
 						},
 					},
 				},
@@ -103,16 +100,19 @@ func TestUpdateFixedByWithDataFromNVD(t *testing.T) {
 				{
 					Cpe23Uri:            "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
 					VersionEndExcluding: "1.2.7",
+					Vulnerable:          true,
 				},
 				{
 					Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
 					VersionStartIncluding: "1.3.0",
 					VersionEndExcluding:   "1.3.9",
+					Vulnerable:            true,
 				},
 				{
 					Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
 					VersionStartIncluding: "1.4.0",
 					VersionEndExcluding:   "1.4.3",
+					Vulnerable:            true,
 				},
 			},
 		},


### PR DESCRIPTION

- Completely remove CPEs that do not provide applicability information (On central side such are CPE are considered as match).
- Add `Vulnerable: true` prop. Since the bundle is public, `Vulnerable: false` is misrepresentation.