### PR TITLE
Add missing CVEs

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -59,8 +59,8 @@ func runCmd() error {
 	groups := splitCVEs(specs, allCVEs)
 
 	// Update fixed by version for NVD CVEs that do not have it but has been determined by manual audit.
-	for _, cves := range groups {
-		nvd.FillMissingData(cves...)
+	for project, cves := range groups {
+		nvd.FillMissingData(project, cves)
 	}
 
 	// Do some logging for the resulting groups of CVEs.

--- a/nvd/enricher.go
+++ b/nvd/enricher.go
@@ -19,73 +19,26 @@ const (
 	NotApplicable = "-"
 )
 
-var (
-	// cvesWithoutFixedBy represents NVD CVEs that may not have correct fixed by version
-	cvesWithoutFixedBy = map[string][]*schema.NVDCVEFeedJSON10DefNode{
-		// https://github.com/kubernetes/kubernetes/issues/19479
-		"CVE-2016-1905": {
-			{
-				Operator: "OR",
-				CPEMatch: []*schema.NVDCVEFeedJSON10DefCPEMatch{
-					{
-						Cpe23Uri:            "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
-						VersionEndExcluding: "1.2.0",
-						Vulnerable:          true,
-					},
-				},
-			},
-		},
-		// https://access.redhat.com/errata/RHSA-2016:0351
-		// https://access.redhat.com/errata/RHSA-2016:0070
-		"CVE-2016-1906": {
-			{
-				Operator: "OR",
-				CPEMatch: []*schema.NVDCVEFeedJSON10DefCPEMatch{
-					{
-						Cpe23Uri:   "cpe:2.3:a:redhat:openshift_container_platform:3.0.0:*:*:*:*:*:*:*",
-						Vulnerable: true,
-					},
-					{
-						Cpe23Uri:   "cpe:2.3:a:redhat:openshift_container_platform:3.1.0:*:*:*:*:*:*:*",
-						Vulnerable: true,
-					},
-				},
-			},
-		},
-		// https://github.com/kubernetes/kubernetes/issues/34517
-		"CVE-2016-7075": {
-			{
-				Operator: "OR",
-				CPEMatch: []*schema.NVDCVEFeedJSON10DefCPEMatch{
-					{
-						Cpe23Uri:            "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
-						VersionEndExcluding: "1.2.7",
-						Vulnerable:          true,
-					},
-					{
-						Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
-						VersionStartIncluding: "1.3.0",
-						VersionEndExcluding:   "1.3.9",
-						Vulnerable:            true,
-					},
-					{
-						Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
-						VersionStartIncluding: "1.4.0",
-						VersionEndExcluding:   "1.4.3",
-						Vulnerable:            true,
-					},
-				},
-			},
-		},
-	}
-)
-
 // FillMissingData fills NVD CVEs with missing data, e.g. affected product versions
-func FillMissingData(cves ...*schema.NVDCVEFeedJSON10DefCVEItem) {
-	tryUpdateCVEWithAffectedVersions(cves...)
+func FillMissingData(project Project, cves []*schema.NVDCVEFeedJSON10DefCVEItem) {
+	addMissingCVEs(project, &cves)
+	tryUpdateCVEWithAffectedVersions(cves)
 }
 
-func tryUpdateCVEWithAffectedVersions(cves ...*schema.NVDCVEFeedJSON10DefCVEItem) {
+func addMissingCVEs(project Project, cves *[]*schema.NVDCVEFeedJSON10DefCVEItem) {
+	cvesFromNVD := make(map[string]struct{})
+	for _, cve := range *cves {
+		cvesFromNVD[cve.CVE.CVEDataMeta.ID] = struct{}{}
+	}
+
+	for _, cve := range cvesNotInDataFeed[project] {
+		if _, ok := cvesFromNVD[cve.CVE.CVEDataMeta.ID]; !ok {
+			*cves = append(*cves, cve)
+		}
+	}
+}
+
+func tryUpdateCVEWithAffectedVersions(cves []*schema.NVDCVEFeedJSON10DefCVEItem) {
 	for _, cve := range cves {
 		if _, ok := cvesWithoutFixedBy[cve.CVE.CVEDataMeta.ID]; !ok {
 			continue

--- a/nvd/enricher_test.go
+++ b/nvd/enricher_test.go
@@ -53,8 +53,7 @@ func TestUpdateFixedByWithNoDataFromNVD(t *testing.T) {
 		},
 	}
 
-	tryUpdateCVEWithAffectedVersions(cve)
-
+	tryUpdateCVEWithAffectedVersions([]*schema.NVDCVEFeedJSON10DefCVEItem{cve})
 	assert.EqualValues(t, expectedCPENodes, cve.Configurations.Nodes)
 
 }
@@ -118,7 +117,77 @@ func TestUpdateFixedByWithDataFromNVD(t *testing.T) {
 		},
 	}
 
-	tryUpdateCVEWithAffectedVersions(cve)
-
+	tryUpdateCVEWithAffectedVersions([]*schema.NVDCVEFeedJSON10DefCVEItem{cve})
 	assert.EqualValues(t, expectedCPENodes, cve.Configurations.Nodes)
+}
+
+func TestAddMissing(t *testing.T) {
+	incomingCVEs := []*schema.NVDCVEFeedJSON10DefCVEItem{
+		{
+			CVE: &schema.CVEJSON40{
+				CVEDataMeta: &schema.CVEJSON40CVEDataMeta{
+					ID: "Blah",
+				},
+			},
+		},
+	}
+
+	addMissingCVEs(Kubernetes, &incomingCVEs)
+	assert.EqualValues(t, cvesNotInDataFeed[Kubernetes]["CVE-2020-8551"].Configurations.Nodes, incomingCVEs[1].Configurations.Nodes)
+	assert.EqualValues(t, cvesNotInDataFeed[Kubernetes]["CVE-2020-8552"].Configurations.Nodes, incomingCVEs[2].Configurations.Nodes)
+}
+
+func TestAddMissingWithUpdate(t *testing.T) {
+	incomingCVEs := []*schema.NVDCVEFeedJSON10DefCVEItem{
+		{
+			CVE: &schema.CVEJSON40{
+				CVEDataMeta: &schema.CVEJSON40CVEDataMeta{
+					ID: "CVE-2020-8551",
+				},
+			},
+			Configurations: &schema.NVDCVEFeedJSON10DefConfigurations{
+				Nodes: []*schema.NVDCVEFeedJSON10DefNode{},
+			},
+		},
+		{
+			CVE: &schema.CVEJSON40{
+				CVEDataMeta: &schema.CVEJSON40CVEDataMeta{
+					ID: "CVE-2020-8552",
+				},
+			},
+			Configurations: &schema.NVDCVEFeedJSON10DefConfigurations{
+				Nodes: []*schema.NVDCVEFeedJSON10DefNode{},
+			},
+		},
+	}
+
+	expectedCVEs := []*schema.NVDCVEFeedJSON10DefCVEItem{
+		{
+			CVE: &schema.CVEJSON40{
+				CVEDataMeta: &schema.CVEJSON40CVEDataMeta{
+					ID: "CVE-2020-8551",
+				},
+			},
+			Configurations: &schema.NVDCVEFeedJSON10DefConfigurations{
+				Nodes: []*schema.NVDCVEFeedJSON10DefNode{},
+			},
+		},
+		{
+			CVE: &schema.CVEJSON40{
+				CVEDataMeta: &schema.CVEJSON40CVEDataMeta{
+					ID: "CVE-2020-8552",
+				},
+			},
+			Configurations: &schema.NVDCVEFeedJSON10DefConfigurations{
+				Nodes: []*schema.NVDCVEFeedJSON10DefNode{},
+			},
+		},
+	}
+
+	addMissingCVEs(Kubernetes, &incomingCVEs)
+	assert.EqualValues(t, expectedCVEs, incomingCVEs)
+
+	tryUpdateCVEWithAffectedVersions(incomingCVEs)
+	assert.EqualValues(t, cvesNotInDataFeed[Kubernetes]["CVE-2020-8551"].Configurations.Nodes, incomingCVEs[0].Configurations.Nodes)
+	assert.EqualValues(t, cvesNotInDataFeed[Kubernetes]["CVE-2020-8552"].Configurations.Nodes, incomingCVEs[1].Configurations.Nodes)
 }

--- a/nvd/missing_cves.go
+++ b/nvd/missing_cves.go
@@ -1,0 +1,96 @@
+package nvd
+
+import "github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
+
+var (
+	// cvesNotInDataFeed represents NVD CVEs that may not be available in NVD data feeds
+	cvesNotInDataFeed = map[Project]map[string]*schema.NVDCVEFeedJSON10DefCVEItem{
+		Kubernetes: {
+			"CVE-2020-8551": {
+				PublishedDate:    "2020-03-27T15:15Z",
+				LastModifiedDate: "2020-03-27T16:03Z",
+				CVE: &schema.CVEJSON40{
+					CVEDataMeta: &schema.CVEJSON40CVEDataMeta{
+						ID: "CVE-2020-8551",
+					},
+					Description: &schema.CVEJSON40Description{
+						DescriptionData: []*schema.CVEJSON40LangString{
+							{
+								Value: "The Kubelet component in versions 1.15.0-1.15.9, 1.16.0-1.16.6, and 1.17.0-1.17.2 has been found to be vulnerable to a denial of service attack via the kubelet API, including the unauthenticated HTTP read-only API typically served on port 10255, and the authenticated HTTPS API typically served on port 10250.",
+							},
+						},
+					},
+				},
+				Configurations: &schema.NVDCVEFeedJSON10DefConfigurations{
+					Nodes: []*schema.NVDCVEFeedJSON10DefNode{
+						{
+							Operator: "OR",
+							CPEMatch: []*schema.NVDCVEFeedJSON10DefCPEMatch{
+								{
+									Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
+									VersionStartIncluding: "1.15.0",
+									VersionEndIncluding:   "1.15.9",
+									Vulnerable:            true,
+								},
+								{
+									Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
+									VersionStartIncluding: "1.16.0",
+									VersionEndIncluding:   "1.16.6",
+									Vulnerable:            true,
+								},
+								{
+									Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
+									VersionStartIncluding: "1.17.0",
+									VersionEndIncluding:   "1.17.2",
+									Vulnerable:            true,
+								},
+							},
+						},
+					},
+				},
+			},
+			"CVE-2020-8552": {
+				PublishedDate:    "2020-03-27T15:15Z",
+				LastModifiedDate: "2020-03-27T16:03Z",
+				CVE: &schema.CVEJSON40{
+					CVEDataMeta: &schema.CVEJSON40CVEDataMeta{
+						ID: "CVE-2020-8552",
+					},
+					Description: &schema.CVEJSON40Description{
+						DescriptionData: []*schema.CVEJSON40LangString{
+							{
+								Value: "The Kubernetes API server component in versions prior to 1.15.9, 1.16.0-1.16.6, and 1.17.0-1.17.2 has been found to be vulnerable to a denial of service attack via successful API requests.",
+							},
+						},
+					},
+				},
+				Configurations: &schema.NVDCVEFeedJSON10DefConfigurations{
+					Nodes: []*schema.NVDCVEFeedJSON10DefNode{
+						{
+							Operator: "OR",
+							CPEMatch: []*schema.NVDCVEFeedJSON10DefCPEMatch{
+								{
+									Cpe23Uri:            "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
+									VersionEndExcluding: "1.15.9",
+									Vulnerable:          true,
+								},
+								{
+									Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
+									VersionStartIncluding: "1.16.0",
+									VersionEndIncluding:   "1.16.6",
+									Vulnerable:            true,
+								},
+								{
+									Cpe23Uri:            "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
+									VersionEndExcluding: "1.17.0",
+									VersionEndIncluding: "1.17.2",
+									Vulnerable:          true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+)

--- a/nvd/stale_cves.go
+++ b/nvd/stale_cves.go
@@ -1,0 +1,113 @@
+package nvd
+
+import "github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
+
+var (
+	// cvesWithoutFixedBy represents NVD CVEs that may not have correct fixed by version
+	cvesWithoutFixedBy = map[string][]*schema.NVDCVEFeedJSON10DefNode{
+		// https://github.com/kubernetes/kubernetes/issues/19479
+		"CVE-2016-1905": {
+			{
+				Operator: "OR",
+				CPEMatch: []*schema.NVDCVEFeedJSON10DefCPEMatch{
+					{
+						Cpe23Uri:            "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
+						VersionEndExcluding: "1.2.0",
+						Vulnerable:          true,
+					},
+				},
+			},
+		},
+		// https://access.redhat.com/errata/RHSA-2016:0351
+		// https://access.redhat.com/errata/RHSA-2016:0070
+		"CVE-2016-1906": {
+			{
+				Operator: "OR",
+				CPEMatch: []*schema.NVDCVEFeedJSON10DefCPEMatch{
+					{
+						Cpe23Uri:   "cpe:2.3:a:redhat:openshift_container_platform:3.0.0:*:*:*:*:*:*:*",
+						Vulnerable: true,
+					},
+					{
+						Cpe23Uri:   "cpe:2.3:a:redhat:openshift_container_platform:3.1.0:*:*:*:*:*:*:*",
+						Vulnerable: true,
+					},
+				},
+			},
+		},
+		// https://github.com/kubernetes/kubernetes/issues/34517
+		"CVE-2016-7075": {
+			{
+				Operator: "OR",
+				CPEMatch: []*schema.NVDCVEFeedJSON10DefCPEMatch{
+					{
+						Cpe23Uri:            "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
+						VersionEndExcluding: "1.2.7",
+						Vulnerable:          true,
+					},
+					{
+						Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
+						VersionStartIncluding: "1.3.0",
+						VersionEndExcluding:   "1.3.9",
+						Vulnerable:            true,
+					},
+					{
+						Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
+						VersionStartIncluding: "1.4.0",
+						VersionEndExcluding:   "1.4.3",
+						Vulnerable:            true,
+					},
+				},
+			},
+		},
+		"CVE-2020-8551": {
+			{
+				Operator: "OR",
+				CPEMatch: []*schema.NVDCVEFeedJSON10DefCPEMatch{
+					{
+						Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
+						VersionStartIncluding: "1.15.0",
+						VersionEndIncluding:   "1.15.9",
+						Vulnerable:            true,
+					},
+					{
+						Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
+						VersionStartIncluding: "1.16.0",
+						VersionEndIncluding:   "1.16.6",
+						Vulnerable:            true,
+					},
+					{
+						Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
+						VersionStartIncluding: "1.17.0",
+						VersionEndIncluding:   "1.17.2",
+						Vulnerable:            true,
+					},
+				},
+			},
+		},
+		"CVE-2020-8552": {
+			{
+				Operator: "OR",
+				CPEMatch: []*schema.NVDCVEFeedJSON10DefCPEMatch{
+					{
+						Cpe23Uri:            "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
+						VersionEndExcluding: "1.15.9",
+						Vulnerable:          true,
+					},
+					{
+						Cpe23Uri:              "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
+						VersionStartIncluding: "1.16.0",
+						VersionEndIncluding:   "1.16.6",
+						Vulnerable:            true,
+					},
+					{
+						Cpe23Uri:            "cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*",
+						VersionEndExcluding: "1.17.0",
+						VersionEndIncluding: "1.17.2",
+						Vulnerable:          true,
+					},
+				},
+			},
+		},
+	}
+)


### PR DESCRIPTION
- This PR adds newly found NVD CVEs not captured by crawler.

Some CVEs listed on NVD may not have CPE information(affected version information). This is highly likely with the newly added CVEs. If other sources, such as CVE description, github pull requests, bugzilla, etc. provides information about affected versions, we build the CPE strings ourselves and add it to the GCP bucket.

It is unclear how long before the CVEs are completely updated. Hence to provide better view of Vulns to our customers, we add them.